### PR TITLE
Use alternate control flow in app handler for comprehension

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -15,19 +15,20 @@ const prefix = 'merged';
 const storage = uploadToS3({ bucket, prefix });
 const uploadPDF = storePDF({ storage });
 
-exports.handler = function (event, context) {
+exports.handler = async function (event, context) {
   console.time('Lambda runtime');
 
-  downloadPdfs(event.body.pdfUrls)
-    .then(mergePDFs)
-    .then(uploadPDF)
-    .then(formatResponse)
-    .then(function (response) {
-      context.succeed(response);
-      console.log('Response:', response);
-      console.timeEnd('Lambda runtime');
-    })
-    .catch(function (error) {
-      console.log('Something went wrong:', error);
-    });
+  try {
+    const filepaths = await downloadPdfs(event.body.pdfUrls);
+    const buffer = await mergePDFs(filepaths);
+    const url = await uploadPDF(buffer);
+    const response = formatResponse(url);
+
+    context.succeed(response);
+    console.log('Response:', response);
+  } catch (error) {
+    console.log('Something went wrong:', error);
+  } finally {
+    console.timeEnd('Lambda runtime');
+  }
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -15,20 +15,25 @@ const prefix = 'merged';
 const storage = uploadToS3({ bucket, prefix });
 const uploadPDF = storePDF({ storage });
 
-exports.handler = async function (event, context) {
-  console.time('Lambda runtime');
+const mergeUrls = async urls => {
+  const filepaths = await downloadPdfs(urls);
+  const buffer = await mergePDFs(filepaths);
 
-  try {
-    const filepaths = await downloadPdfs(event.body.pdfUrls);
-    const buffer = await mergePDFs(filepaths);
-    const url = await uploadPDF(buffer);
-    const response = formatResponse(url);
+  return uploadPDF(buffer);
+};
 
-    context.succeed(response);
-    console.log('Response:', response);
-  } catch (error) {
-    console.log('Something went wrong:', error);
-  } finally {
-    console.timeEnd('Lambda runtime');
-  }
-}
+exports.handler = (event, context) => {
+  console.time("Lambda runtime");
+
+  const merge = mergeUrls(event.body.pdfUrls);
+
+  merge.then(url => {
+    context.succeed(formatResponse(url));
+    console.log("Response:", response);
+    console.timeEnd("Lambda runtime");
+  });
+
+  merge.catch(error => {
+    console.log("Something went wrong:", error);
+  });
+};


### PR DESCRIPTION
I submit this as a proposal, though I don't know if it is more understandable.

This change swaps using `Promise#then` in favor of `await`, which is used
in the internal implementation of each of the component functions.

Is this easier to understand, or is the variable assignment excess noise?