### PR TITLE
Fix prefix configuration for uploading to S3

### DIFF
--- a/lib/storePdf.js
+++ b/lib/storePdf.js
@@ -4,18 +4,15 @@ import uuid from 'node-uuid';
  * Sends request to upload a PDF using the provided storage method.
  * @param {Object} config
  * @param {Function} config.storage - The function that will upload the PDF.
- * @param {String} config.prefix - The S3 folder name where the merged PDF
- *   will be uploaded.
  * @returns {storePdf~send} - Function which stores the contents of a buffer
  *   and returns the URL of the stored file.
  * @example
- * const storage = uploadToS3({ bucket: 'test-bucket', prefix: 'merged' });
+ * const storage = (filepath, buffer) => #...;
  * const uploadPDF = storePDF({ storage });
- * uploadPDF(mergePdfs)
+ * uploadPDF("<file contents>");
  */
 function storePDF(config) {
   const storage = config.storage;
-  const prefix = config.prefix;
 
   /**
    * @name storePdf~send
@@ -25,7 +22,7 @@ function storePDF(config) {
   return async function send(buffer) {
     console.time('Store merged PDF');
 
-    const filepath = `${prefix}/${uuid.v4()}.pdf`;
+    const filepath = `${uuid.v4()}.pdf`;
     const url = await storage(filepath, buffer);
 
     console.timeEnd('Store merged PDF');

--- a/lib/uploadToS3.js
+++ b/lib/uploadToS3.js
@@ -5,17 +5,17 @@ AWS.config.setPromisesDependency(null);
 /**
  * Uploads a file to an S3 bucket.
  * @param {Object} config
- * @param {String} config.bucket - The S3 bucket name to where merged PDFs
- *   will be uploaded.
+ * @param {String} config.bucket - The S3 bucket name
+ * @param {String} config.prefix - The S3 folder name
  * @returns {uploadToS3~send} - Function that uploads the merged PDF to S3
  *   and returns the location URL.
  * @example
- * const storage = uploadToS3({ bucket: 'test-bucket' });
- * const uploadPDF = storePDF({ storage });
- * uploadPDF(mergePdfs)
+ * const storage = uploadToS3({ bucket: 'test-bucket', prefix: 'merged' });
+ * uploadToS3("foo.pdf", "<file contents>");
  */
 function uploadToS3(config) {
   const bucket = config.bucket;
+  const prefix = config.prefix;
 
   /**
    * @name uploadToS3~send
@@ -25,7 +25,12 @@ function uploadToS3(config) {
    */
   return async function send(key, buffer) {
     const s3 = new AWS.S3();
-    const params = { Bucket: bucket, Key: key, Body: buffer, ACL: 'public-read' };
+    const params = {
+      Bucket: bucket,
+      Key: `${prefix}/${key}`,
+      Body: buffer,
+      ACL: 'public-read'
+    };
     const uploadResponse = await s3.upload(params).promise();
     return uploadResponse['Location'];
   };

--- a/test/uploadToS3.test.js
+++ b/test/uploadToS3.test.js
@@ -7,9 +7,10 @@ import sinon from 'sinon';
 import uploadToS3 from '../lib/uploadToS3';
 
 describe('uploadToS3 module', function () {
-  it('returns function', function (done) {
-    expect(uploadToS3({ bucket: 'foo-bar' })).to.be.an.instanceof(Function);
-    done();
+  it('returns function', function () {
+    const upload = uploadToS3({ bucket: 'foo-bar', prefix: 'merged' });
+
+    expect(upload).to.be.an.instanceof(Function);
   });
 
   it('passes in params to upload function', function (done) {
@@ -22,13 +23,17 @@ describe('uploadToS3 module', function () {
     };
 
     AWS.S3.prototype.upload = sinon.stub().returns(uploadPromise);
-    const upload = uploadToS3({ bucket: 'foo-bar'});
+
+    const upload = uploadToS3({
+      bucket: 'foo-bar',
+      prefix: 'merged'
+    });
 
     upload('foo.pdf', 'bodybodybodybody').then(function (response) {
       const stubArgs = AWS.S3.prototype.upload.firstCall.args[0];
 
       expect(stubArgs['Bucket']).to.equal('foo-bar');
-      expect(stubArgs['Key']).to.equal('foo.pdf');
+      expect(stubArgs['Key']).to.equal('merged/foo.pdf');
       expect(stubArgs['Body']).to.equal('bodybodybodybody');
       expect(stubArgs['ACL']).to.equal('public-read');
       done();
@@ -45,7 +50,11 @@ describe('uploadToS3 module', function () {
     };
 
     AWS.S3.prototype.upload = sinon.stub().returns(uploadPromise);
-    const upload = uploadToS3({ bucket: 'foo-bar'});
+
+    const upload = uploadToS3({
+      bucket: 'foo-bar',
+      prefix: 'merged'
+    });
 
     upload('foo.pdf', 'wire-o').then(function (response) {
       expect(response).to.equal('https://s3.amazonaws.com/superglue/hello.pdf');


### PR DESCRIPTION
There was a mixup where the `prefix` configuration was being passed (correctly) into `uploadToS3` in the `app.js` file, but the documentation and implementation was to provide this to the `uploadPdf` function. In order to keep `uploadPdf` agnostic about what backend is being used, I've chosen to retain the `app.js` implementation and change the documentation and the implementation to match.